### PR TITLE
Fix link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parse-EZ : Clojure Parser Library
 
-[api]: http://www.protoflex.com/parse-ez/api-doc/protoflex.parse-api.html "Parse-EZ API"
+[api]: https://www.protoflex.com/protoflex.parse-api.html "Parse-EZ API"
 [API Documentation][api]
 
 Parse-EZ is a parser library for Clojure programmers. It allows easy


### PR DESCRIPTION
This link is broken, and should use https://